### PR TITLE
Stop application before destroying it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ endef
 export PRINT_HELP_PYSCRIPT
 
 TEST_REGION="us-west-2"
-TEST_ROLE="arn:aws:iam::303467602807:role/sqs-ecs-tester"
-#TEST_ROLE="arn:aws:iam::493370826424:role/ih-tf-aws-control-493370826424-admin"
+TEST_ROLE="arn:aws:iam::303467602807:role/emrserverless-tester"
 
 help: install-hooks
 	@python -c "$$PRINT_HELP_PYSCRIPT" < Makefile


### PR DESCRIPTION
Terraform/AWS can't destroy an application if it's not STOPPED.
From UX perspective it's obvious that if a user wants the application to be deleted they don't want it to be running.
Nonetheless, it is what it is. The test stops the application before the resources are destroyed.
