### PR TITLE
Add feature flag for scheduler_configuration compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_application_name"></a> [application\_name](#input\_application\_name) | Name of application | `string` | n/a | yes |
+| <a name="input_enable_scheduler_configuration"></a> [enable\_scheduler\_configuration](#input\_enable\_scheduler\_configuration) | Enable scheduler configuration (supported in AWS provider 6.x+) | `bool` | `true` | no |
 | <a name="input_extra_policy_arns"></a> [extra\_policy\_arns](#input\_extra\_policy\_arns) | Map of IAM policy ARNs to attach to the job execution role | `map(string)` | `{}` | no |
+| <a name="input_max_concurrent_runs"></a> [max\_concurrent\_runs](#input\_max\_concurrent\_runs) | Maximum number of concurrent runs (scheduler\_configuration - AWS provider 6.x+) | `number` | `15` | no |
+| <a name="input_queue_timeout_minutes"></a> [queue\_timeout\_minutes](#input\_queue\_timeout\_minutes) | Queue timeout in minutes (scheduler\_configuration - AWS provider 6.x+) | `number` | `360` | no |
 | <a name="input_storage_bucket_name"></a> [storage\_bucket\_name](#input\_storage\_bucket\_name) | Name of storage bucket | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -9,30 +9,15 @@ resource "aws_emrserverless_application" "emr_application" {
     local.default_module_tags,
   )
 
-  # maximum_capacity {
-  #   cpu    = var.application_max_cores
-  #   memory = var.application_max_memory
-  # }
-  #
-  # initial_capacity {
-  #   initial_capacity_type = "Driver"
-  #
-  #   dynamic "initial_capacity_config" {
-  #     for_each = var.initial_worker_count == null ? [] : [1]
-  #
-  #     content {
-  #       worker_count = var.initial_worker_count
-  #
-  #       dynamic "worker_configuration" {
-  #         for_each = [1] #?
-  #
-  #         content {
-  #           cpu    = var.initial_worker_cpu
-  #           memory = var.initial_worker_memory
-  #         }
-  #       }
-  #     }
-  #   }
+  dynamic "scheduler_configuration" {
+    for_each = var.enable_scheduler_configuration ? [1] : []
+
+    content {
+      max_concurrent_runs   = var.max_concurrent_runs
+      queue_timeout_minutes = var.queue_timeout_minutes
+    }
+  }
+
 }
 
 

--- a/test_data/emrserverless/main.tf
+++ b/test_data/emrserverless/main.tf
@@ -5,4 +5,5 @@ module "test" {
   extra_policy_arns = {
     elasticmapreduce : aws_iam_policy.job_exec_role_permissions.arn
   }
+  enable_scheduler_configuration = var.enable_scheduler_configuration
 }

--- a/test_data/emrserverless/variables.tf
+++ b/test_data/emrserverless/variables.tf
@@ -2,3 +2,8 @@ variable "region" {}
 variable "role_arn" {
   default = null
 }
+variable "enable_scheduler_configuration" {
+  description = "Enable scheduler configuration (supported in AWS provider 6.x+)"
+  type        = bool
+  default     = true
+}

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -39,11 +39,16 @@ def test_module(
         except FileNotFoundError:
             pass
 
+    # Determine if scheduler_configuration is supported based on provider version
+    # For AWS provider 5.x, disable scheduler_configuration
+    enable_scheduler = "true" if aws_provider_version.startswith("~> 6") else "false"
+
     with open(osp.join(terraform_module_dir, "terraform.tfvars"), "w") as fp:
         fp.write(
             dedent(
                 f"""
                     region              = "{aws_region}"
+                    enable_scheduler_configuration = {enable_scheduler}
                     """
             )
         )

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,21 @@ variable "extra_policy_arns" {
   type        = map(string)
   default     = {}
 }
+
+variable "enable_scheduler_configuration" {
+  description = "Enable scheduler configuration (supported in AWS provider 6.x+)"
+  type        = bool
+  default     = true
+}
+
+variable "max_concurrent_runs" {
+  description = "Maximum number of concurrent runs (scheduler_configuration - AWS provider 6.x+)"
+  type        = number
+  default     = 15
+}
+
+variable "queue_timeout_minutes" {
+  description = "Queue timeout in minutes (scheduler_configuration - AWS provider 6.x+)"
+  type        = number
+  default     = 360
+}


### PR DESCRIPTION
  - Add `enable_scheduler_configuration` boolean variable to control scheduler_configuration block
  - Convert static scheduler_configuration to dynamic block based on feature flag
  - Add `max_concurrent_runs` and `queue_timeout_minutes` variables for customization
  - Update tests to disable scheduler_configuration for AWS provider 5.x and enable for 6.x
